### PR TITLE
Deprecate inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # heimdall_tools_action
-THIS ACTION IS DEPRECATED. Use mitre/saf_action to replace this action. Find it here: https://github.com/mitre/saf_action
+THIS ACTION IS DEPRECATED. Use the [SAF Action](https://github.com/marketplace/actions/saf-cli-action) instead.
 
 GitHub Action for [Heimdall Tools](https://github.com/mitre/heimdall_tools)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # heimdall_tools_action
+THIS ACTION IS DEPRECATED. Use mitre/saf_action to replace this action. Find it here: https://github.com/mitre/saf_action
+
 GitHub Action for [Heimdall Tools](https://github.com/mitre/heimdall_tools)
 
 Easily convert supported formats to Heimdall Data Format for use with Heimdall Enterprise Server, Heimdall Lite, or any other HDF-compatible viewer.

--- a/action.yml
+++ b/action.yml
@@ -9,9 +9,11 @@ inputs:
   file:
     description: 'File to convert into HDF'
     required: true
+    deprecationMessage: 'THIS ACTION IS DEPRECATED. Use mitre/saf_action to replace this action. Find it here: https://github.com/mitre/saf_action'
   converter:
     description: 'Specify which convert to use to convert <file-to-convert>'
     requried: true
+    deprecationMessage: 'THIS ACTION IS DEPRECATED. Use mitre/saf_action to replace this action. Find it here: https://github.com/mitre/saf_action'
 outputs:
   hdf-output:
     description: 'HDF output of <file-to-convert>'

--- a/action.yml
+++ b/action.yml
@@ -9,11 +9,11 @@ inputs:
   file:
     description: 'File to convert into HDF'
     required: true
-    deprecationMessage: 'THIS ACTION IS DEPRECATED. Use mitre/saf_action to replace this action. Find it here: https://github.com/mitre/saf_action'
+    deprecationMessage: 'THIS ACTION IS DEPRECATED. Use mitre/saf_action to replace this action. Find it here: https://github.com/marketplace/actions/saf-cli-action'
   converter:
     description: 'Specify which convert to use to convert <file-to-convert>'
     requried: true
-    deprecationMessage: 'THIS ACTION IS DEPRECATED. Use mitre/saf_action to replace this action. Find it here: https://github.com/mitre/saf_action'
+    deprecationMessage: 'THIS ACTION IS DEPRECATED. Use mitre/saf_action to replace this action. Find it here: https://github.com/marketplace/actions/saf-cli-action'
 outputs:
   hdf-output:
     description: 'HDF output of <file-to-convert>'


### PR DESCRIPTION
Closes #2 
- Added deprecation messages to the input to point use to [SAF Action](https://github.com/marketplace/actions/saf-cli-action).
- Added deprecation message and SAF Action link to the Readme.
This is a test workflow output with the deprecation message on the inputs.
![image](https://user-images.githubusercontent.com/32680215/157131186-2a5017d0-ed4c-4db2-b41a-a2035b3afd00.png)
The workflow tests still pass, but the inputs show as deprecated with the corresponding message.